### PR TITLE
Recognize RFC3339 dates when ending in Z instead of +HH:DD.

### DIFF
--- a/json-to-go.js
+++ b/json-to-go.js
@@ -119,7 +119,7 @@ function jsonToGo(json, typename)
 		switch (typeof val)
 		{
 			case "string":
-				if (/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\+\d\d:\d\d/.test(val))
+				if (/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\+\d\d:\d\d|Z)/.test(val))
 					return "time.Time";
 				else
 					return "string";


### PR DESCRIPTION
In RFC3339, dates can end in Z, meaning +00:00.