### PR TITLE
Fix time parsing for precision, and float -> issue.

### DIFF
--- a/json-to-go.js
+++ b/json-to-go.js
@@ -16,7 +16,7 @@ function jsonToGo(json, typename)
 
 	try
 	{
-		data = JSON.parse(json);
+		data = JSON.parse(json.replace(/\.0/g, ".1"));
 		scope = data;
 	}
 	catch (e)
@@ -119,7 +119,7 @@ function jsonToGo(json, typename)
 		switch (typeof val)
 		{
 			case "string":
-				if (/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\+\d\d:\d\d|Z)/.test(val))
+				if (/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(\+\d\d:\d\d|Z)/.test(val))
 					return "time.Time";
 				else
 					return "string";


### PR DESCRIPTION
Because Javascript can't tell the difference between `1.0` and `1` you end up with Go structs that are using `int` where `float` is required. This PR hacks around this by doing a global substitution on the incoming buffer to replace `.0` with `.1`. This will probably almost always do the right thing. There could be places where the key name is meant to be a string and has a `.0` in it. That seems reasonably pathological to me so I believe this solution is good enough.

Secondly, precision times with mill/nano-seconds were not parsing into `time.Time` types and this fixes that.

Thanks for the great tool!