### PR TITLE
Keep upper-case characters (#14)

### DIFF
--- a/json-to-go.js
+++ b/json-to-go.js
@@ -167,13 +167,19 @@ function jsonToGo(json, typename)
 			"SMTP", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "UID", "UUID", "URI", 
 			"URL", "UTF8", "VM", "XML", "XSRF", "XSS"
 		];
-	
-		return str.replace(/(^|[^a-z])([a-z]+)/ig, function(unused, sep, frag)
+
+		return str.replace(/(^|[^a-zA-Z])([a-z]+)/g, function(unused, sep, frag)
 		{
 			if (commonInitialisms.indexOf(frag.toUpperCase()) >= 0)
 				return sep + frag.toUpperCase();
 			else
 				return sep + frag[0].toUpperCase() + frag.substr(1).toLowerCase();
+		}).replace(/([A-Z])([a-z]+)/g, function(unused, sep, frag)
+		{
+			if (commonInitialisms.indexOf(sep + frag.toUpperCase()) >= 0)
+				return (sep + frag).toUpperCase();
+			else
+				return sep + frag;
 		});
 	}
 }


### PR DESCRIPTION
This PR changes the way in which JSON keys are converted into Go keys to keep upper-case characters. For example, a JSON key 'fooBar' is converted 'FooBar' instead of 'Foobar'.

Here are the test cases:

```js
jsonToGo(JSON.stringify({foo_bar: 1, fooBaz: 2, foo_url_baz: 3, fooURLbaz: 4})).go
```

```go
type AutoGenerated struct {
	FooBar int `json:"foo_bar"`
	FooBaz int `json:"fooBaz"`
	FooURLBaz int `json:"foo_url_baz"`
	FooURLbaz int `json:"fooURLbaz"`
}
```