### PR TITLE
Fix issue #18: support nested array

### DIFF
--- a/json-to-go.js
+++ b/json-to-go.js
@@ -92,6 +92,9 @@ function jsonToGo(json, typename)
 
 					parseStruct(struct, omitempty); // finally parse the struct !!
 				}
+				else if (sliceType == "slice") {
+					parseScope(scope[0])
+				}
 				else
 					append(sliceType || "interface{}");
 			}
@@ -181,9 +184,9 @@ function jsonToGo(json, typename)
 			case "boolean":
 				return "bool";
 			case "object":
+				if (Array.isArray(val))
+					return "slice";
 				return "struct";
-			case "array":
-				return "slice";
 			default:
 				return "interface{}";
 		}


### PR DESCRIPTION
Fix "Bug with nested arrays #18", tested on its provided example:

```
var json = `[[[{"abc": "a1"},{"abc": "b1"}]]]`
console.log(jsonToGo(json, "output").go)

// output
type Output [][][]struct {
	Abc string `json:"abc"`
}
```