### PR TITLE
Address issue #17: support node cli & require

### DIFF
--- a/json-to-go.js
+++ b/json-to-go.js
@@ -231,3 +231,14 @@ function jsonToGo(json, typename)
 		});
 	}
 }
+
+if (typeof module != 'undefined') {
+    if (!module.parent) {
+        process.stdin.on('data', function(buf) {
+            var json = buf.toString('utf8')
+            console.log(jsonToGo(json).go)
+        })
+    } else {
+        module.exports = jsonToGo
+    }
+}


### PR DESCRIPTION
Address "Publish CLI to npm? #17", make it both a node module and cli tool (stdin only).  

Tested with:

```
$ cat sample.json | node json-to-go.js
```

and

```node
var j2g = require('./json-to-go.js')
var nested = `[[[{"abc": "a1"},{"abc": "b1"}]]]`
console.log(j2g(nested).go)
```