### PR TITLE
Added service worker with cache first strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@
 	<head>
 		<title>JSON-to-Go: Convert JSON to Go instantly</title>
 		<meta charset="UTF-8">
+		<script>
+			if ('serviceWorker' in navigator) {
+				navigator.serviceWorker.register('./sw.js').then(function(reg) {
+					console.log('Successfully registered service worker', reg);
+				}).catch(function(err) {
+					console.warn('Error whilst registering service worker', err);
+				})
+			}
+		</script>
 		<script src="resources/js/jquery.min.js"></script>
 		<script src="resources/js/highlight.min.js"></script>
 		<script src="resources/js/json-to-go.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,50 @@
+var CACHE = "v1"
+
+var filesToCache = [
+    './',
+    './resources/js/jquery.min.js',
+    './resources/js/highlight.min.js',
+    './resources/js/json-to-go.js',
+    './resources/js/common.js',
+    './resources/js/gofmt.js',
+    './resources/css/tomorrow.highlight.css',
+    './resources/css/common.css',
+    './resources/images/json-to-go.png'
+]
+
+self.addEventListener('install', function (evt) {
+    console.log('Attempting service worker installation.');
+
+    // Wait until promise resolves
+    evt.waitUntil(precache());
+});
+
+// On fetch, return from cache
+self.addEventListener('fetch', function (evt) {
+    evt.respondWith(serve(evt.request));
+});
+
+// Opens cache and loads filesToCache into cache for using them in future
+function precache() {
+    return caches
+        .open(CACHE)
+        .then(function (cache) {
+            return cache.addAll(filesToCache);
+        });
+}
+
+// When a resource is requested first serve from service worker and if service
+// worker hasn't cached that request, then fetch that resource and then serve it
+// This strategy is cache first.
+function serve(request) {
+    return caches
+        .open(CACHE)
+        .then(function (cache) {
+            return cache
+                .match(request)
+                .then(function (matching) {
+                    return matching || fetch(request);
+                })
+                .catch(console.error);
+        });
+}


### PR DESCRIPTION
Hi,

`json-to-go` doesn't really needs internet access once the website has loaded in browser. And sometimes people don't have internet access but they still want to use `json-to-go`. As this tool is hosted on Github pages so we can't really set `Cache-Control` headers but we can use service workers. 

So, I added a service worker with Cache First strategy. There are plenty of browsers that support service workers and once this service worker is installed they'll be able to use `json-to-go` even when they don't have internet access. 

I excluded `analytics.js` from the list of files that should be cached because it'll require internet access.

Regards 
Ishan Jain