### PR TITLE
Add feature to copy contents of output to clipboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 			<tr>
 				<th style="width: 45%;">JSON</th>
 				<th style="width: 10%; font-size: 22px;">&#8594;</th>
-				<th style="width: 45%;">Go <label><input type="checkbox" id="inline" checked>Inline type definitions</label></th>
+				<th style="width: 45%;">Go <label><input type="checkbox" id="inline" checked>Inline type definitions</label> <span class="copy" id="copy-btn">Copy to clipboard</span></th>
 			</tr>
 		</table>
 		<table>

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -127,6 +127,17 @@ footer {
 	border: 1px solid purple;
 }
 
+.copy {
+	font-size: 14px;
+    padding: 5px;
+    background: #80808099;
+	border-radius: 5px;
+	cursor: pointer;
+}
+.copy:hover {
+	background: #808080cf;
+}
+
 @media (max-width: 800px) {
 	.intro {
 		flex-direction: column;

--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -140,6 +140,31 @@ $(function()
 		}
 		dark = !dark;
 	});
+
+	// Copy contents of the output to clipboard
+	$("#copy-btn").click(function() {
+		var elm = document.getElementById("output");
+
+		if(document.body.createTextRange) {
+			// for ie
+			var range = document.body.createTextRange();
+
+			range.moveToElementText(elm);
+			range.select();
+
+			document.execCommand("Copy");
+		} else if(window.getSelection) {
+			// other browsers
+			var selection = window.getSelection();
+			var range = document.createRange();
+
+			range.selectNodeContents(elm);
+			selection.removeAllRanges();
+			selection.addRange(range);
+
+			document.execCommand("Copy");
+		}
+	})
 });
 
 function constructJSONErrorHTML(rawErrorMessage, errorIndex, json) {


### PR DESCRIPTION
I added a copy to clipboard functionality.
Here's how it looks:
![image](https://user-images.githubusercontent.com/13309631/66391331-89810b00-e9ec-11e9-93be-062a1d3932cb.png)
