### PR TITLE
Names that contain '.0' are preserved

### DIFF
--- a/json-to-go.js
+++ b/json-to-go.js
@@ -22,7 +22,7 @@ function jsonToGo(json, typename, flatten = true)
 
 	try
 	{
-		data = JSON.parse(json.replace(/:(.*)\.0/g, ":$1.1")); // hack that forces floats to stay as floats
+		data = JSON.parse(json.replace(/:(\s*\d*)\.0/g, ":$1.1")); // hack that forces floats to stay as floats
 		scope = data;
 	}
 	catch (e)

--- a/json-to-go.js
+++ b/json-to-go.js
@@ -22,7 +22,7 @@ function jsonToGo(json, typename, flatten = true)
 
 	try
 	{
-		data = JSON.parse(json.replace(/\.0/g, ".1")); // hack that forces floats to stay as floats
+		data = JSON.parse(json.replace(/:(.*)\.0/g, ":$1.1")); // hack that forces floats to stay as floats
 		scope = data;
 	}
 	catch (e)


### PR DESCRIPTION
fixes #63 

I saw the messages on the gopher slack and had a little time to investigate.

Your hack that guarantees that floats stay floats was checking every occurence of .0.
 
The regex searches now for occurences of `:<somethings>.0` and replaces it with `:<something>.1`
