### PR TITLE
Add simple bin

### DIFF
--- a/bin/json-to-go
+++ b/bin/json-to-go
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const jsonToGo = require("../json-to-go.js");
+
+async function read(stream) {
+	const chunks = [];
+	for await (const chunk of stream) { 
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+(async function main() {
+	const input = await read(process.stdin);
+	const out = jsonToGo(input);
+	if (out.error) {
+		process.stderr.write(out.error + "\n");	
+		process.exit(4);
+	}
+
+	process.stdout.write(out.go + "\n");
+})();


### PR DESCRIPTION
I've wanted to be able to run this from the command line for a couple years now. This is just a little node js wrapper for the library to make it possible.

There's certainly room to add flags and options and all that but I opted for dead simple read from standard input, write to standard output. Suited my needs anyway, I'm open to making any requested changes.

Should you be interested in publishing an `npm install`-able version, it'd be as easy as creating a package.json including a section:

```json
    "bin": {
        "json-to-go": "./bin/json-to-go"
    },
```

Anway, great tool, use it almost every week.